### PR TITLE
Allow users to choose the path to `refmt`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ prettier src/**/*.re --write --print-width 120
 
 VSCode plugin support is currently [blocked by this issue](https://github.com/prettier/prettier-vscode/issues/395).
 
+### Using other `refmt` binaries
+
+If `refmt` is not in your path or you wanted to use `bsrefmt`, set the environment variable `REFMT_BIN`
+
+```bash
+REFMT_BIN=bsrefmt prettier src/**/*.re --write --print-width 120
+```
+
 ## Credits
 
 This is largly inspired by [prettier-plugin-elm](https://github.com/gicentre/prettier-plugin-elm) so props to them.

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,12 +1,14 @@
 const { sync } = require("execa");
 
-const format = (text, options) =>
-    sync("refmt", ["--print-width=" + options.printWidth], {
+const format = (text, options) => {
+    const refmtProcess = process.env.REFMT_BIN || "refmt";
+    return sync(refmtProcess, ["--print-width=" + options.printWidth], {
         input: text,
         preferLocal: true,
         localDir: __dirname,
         stripEof: false
     }).stdout;
+};
 
 const parse = (text, parsers, opts) => ({
     ast_type: "refmt",


### PR DESCRIPTION
I needed to use `bsrefmt` instead of `refmt` so I added an environment variable called `REFMT_BIN` to control this.